### PR TITLE
Add options to print status and set volume

### DIFF
--- a/stream2chromecast.py
+++ b/stream2chromecast.py
@@ -386,6 +386,20 @@ def stop():
     cast.quit_app()
 
 
+def get_status():
+    """ print the status of the chromecast device """
+    cast = pychromecast.get_chromecast()
+
+    time.sleep(1)
+    print
+    print cast.device
+    print
+    print cast.status
+    print
+    print cast.media_controller.status
+    print
+
+
 def validate_args():
     """ validate that there are the correct number of arguments """
     if len(sys.argv) < 2:
@@ -420,6 +434,9 @@ def run():
     elif arg1 == "-continue":
         unpause()           
     
+    elif arg1 == "-status":
+        get_status()
+
     elif arg1 in ("-transcode"):    
         arg2 = sys.argv[2]  
         play(arg2, transcode=True)   

--- a/stream2chromecast.py
+++ b/stream2chromecast.py
@@ -400,6 +400,31 @@ def get_status():
     print
 
 
+def volume_up():
+    """ raise the volume by 0.1 """
+    cast = get_chromecast()
+
+    cast.volume_up()
+    time.sleep(3)
+
+
+def volume_down():
+    """ lower the volume by 0.1 """
+    cast = get_chromecast()
+
+    cast.volume_down()
+    time.sleep(3)
+
+
+def set_volume(v):
+    """ set the volume to level between 0 and 1 """
+    cast = get_chromecast()
+
+    cast.set_volume(v)
+    time.sleep(3)
+
+
+
 def validate_args():
     """ validate that there are the correct number of arguments """
     if len(sys.argv) < 2:
@@ -436,6 +461,19 @@ def run():
     
     elif arg1 == "-status":
         get_status()
+
+    elif arg1 == "-setvol":
+        arg2 = float(sys.argv[2])
+        set_volume(arg2)
+
+    elif arg1 == "-volup":
+        volume_up()
+
+    elif arg1 == "-voldown":
+        volume_down()
+
+    elif arg1 == "-mute":
+        set_volume(0)
 
     elif arg1 in ("-transcode"):    
         arg2 = sys.argv[2]  


### PR DESCRIPTION
I added a few useful options that are available in PyChromecast but weren't yet included in stream2chromecast. I have found it really useful to be able to control the volume when streaming to Chromecast.

Having direct access to the Chromecast status opens up a wide range of possibilities for scripting interaction with the device. For example, I've used stream2chromecast as the base for my [Chromecast playlist script](https://github.com/dohliam/cast-playlist), and being able to query the status gives access to all sorts of useful information -- the current playing video, the current volume, whether the device is active or muted etc.

There are a few other nice features supported by PyChromecast, such as playing YouTube videos and seeking to a particular point in a video. I'll try to add those eventually too, once I've figured them out.