### PR TITLE
Default ffmpeg transcoding options

### DIFF
--- a/stream2chromecast.py
+++ b/stream2chromecast.py
@@ -232,7 +232,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 class TranscodingRequestHandler(RequestHandler):
     """ Handle HTTP requests for files which require realtime transcoding with ffmpeg """
     transcoder_command = FFMPEG
-    transcode_options = ""
+    transcode_options = "-vcodec libx264 -acodec aac -movflags frag_keyframe+empty_moov"
     transcode_input_options = ""    
     bufsize = 0
                     


### PR DESCRIPTION
I tried transcoding with many options but none worked, I always got a blank screen. By adding the following ffmpeg options `-vcodec libx264 -acodec aac -movflags frag_keyframe+empty_moov` I finally got it to work.

I would suggest adding this options as default to guarantee that any file will play.