### PR TITLE
allow rtsp streams

### DIFF
--- a/stream2chromecast.py
+++ b/stream2chromecast.py
@@ -422,7 +422,7 @@ def play(filename, transcode=False, transcoder=None, transcode_options=None, tra
         filename = os.path.abspath(filename)
         print "source is file: %s" % filename
     else:
-        if transcode and (filename.lower().startswith("http://") or filename.lower().startswith("https://")):
+        if transcode and (filename.lower().startswith("http://") or filename.lower().startswith("https://") or filename.lower().startswith("rtsp://")):
             print "source is URL: %s" % filename
         else: 
             sys.exit("media file %s not found" % filename)


### PR DESCRIPTION
allows rtsp to stream from webcam to chromecast, e.g.: 

stream2chromecast.py -transcode -transcodeopts '-rtsp_transport tcp' -devicename 192.168.0.24 rtsp://webcam:7447/stream/0